### PR TITLE
Update to handle Transaction fee

### DIFF
--- a/ui-src/src/components/page-sub-components/transaction-details-button/TransactionDetailsButton.tsx
+++ b/ui-src/src/components/page-sub-components/transaction-details-button/TransactionDetailsButton.tsx
@@ -193,13 +193,14 @@ class TransactionDetailsButton extends React.Component<Props, State> {
       this.forceReset(proposalResult);
     }
     else if (this.state.nextApiCall === "receive_payment") {
-      const { counterparty, amount, notes, dueDate, inResponseToTX, eventCommitHash, txAuthor,  proposalCommitSignature } = this.props.rowInfo.original; // eventCommitHash,
+      const { counterparty, amount, fee, notes, dueDate, inResponseToTX, eventCommitHash, txAuthor,  proposalCommitSignature } = this.props.rowInfo.original; // eventCommitHash,
       const isoDeadline: Moment = moment(dueDate, moment.ISO_8601);
       const proposal = {
         tx: {
           to: txAuthor,
           from: counterparty,
           amount,
+	  fee,
           notes,
           deadline: isoDeadline,
         },

--- a/ui-src/src/components/page-views/HoloFuelSummaryPage.tsx
+++ b/ui-src/src/components/page-views/HoloFuelSummaryPage.tsx
@@ -61,20 +61,35 @@ class HoloFuelSummaryPage extends React.Component<Props, State> {
       return (
         <div>
           <div className={classes.jumbotron}>
-            <h3 className={classes.h3}>Current Balance</h3>
             <Typography className={classes.mainHeader} variant="display1" gutterBottom={gutterBottom} component="h1" >
-              {this.props.ledger_state.balance ?
-                <div><img src="/assets/icons/holo-logo.png" alt="holo-logo" width="85" className={classes.hcLogoLg} /> {`${this.props.ledger_state.balance}`}</div>
-              : `Pending...`
+              {
+		this.props.ledger_state.balance && this.props.ledger_state.credit && this.props.ledger_state.payable
+		? <div><img src="/assets/icons/holo-logo.png" alt="holo-logo" width="85" className={classes.hcLogoLg} /> {`${this.props.ledger_state.balance + this.props.ledger_state.credit - this.props.ledger_state.payable}`}</div>
+                : `Pending...`
               }
             </Typography>
             <hr style={{color:"#0e094b8f"}} />
             <h3 className={classes.h3}>
-              Credit limit : {this.props.ledger_state.credit && this.props.ledger_state.credit.toString().split(" ")[0] === "-" ?
-                <div><img src="/assets/icons/holo-logo.png" alt="holo-logo" width="25" className={classes.hcLogoSm} style={{color:'#ac62bb'}}/> {`${this.props.ledger_state.credit}`}</div>
-              :
-                <div><img src="/assets/icons/holo-logo.png" alt="holo-logo" width="25" className={classes.hcLogoSm}/> {`${this.props.ledger_state.credit}`}</div>
+              {this.props.ledger_state.credit
+                ? <span>(<img src="/assets/icons/holo-logo.png" alt="holo-logo" width="25" className={classes.hcLogoSm}/>{`${this.props.ledger_state.credit}`} Credit)</span>
+                : <span>Credit</span>
               }
+	      <span> + </span>
+	      {this.props.ledger_state.balance
+                ? <span>(<img src="/assets/icons/holo-logo.png" alt="holo-logo" width="25" className={classes.hcLogoSm}/>{`${this.props.ledger_state.balance}`} Balance)</span>
+                : <span>Balance</span>
+              }
+	      <span> - </span>
+              { this.props.ledger_state.payable
+                ? <span>(<img src="/assets/icons/holo-logo.png" alt="holo-logo" width="25" className={classes.hcLogoSm}/>{`${this.props.ledger_state.payable}`} Payable)</span>
+                : <span>Payable</span>
+              }
+              <div>
+	      { this.props.ledger_state.fees
+                ? <span>(<img src="/assets/icons/holo-logo.png" alt="holo-logo" width="25" className={classes.hcLogoSm}/>{`${this.props.ledger_state.fees}`} Fees)</span>
+                : <span>(Fees)</span>
+              }
+	      </div>
             </h3>
           </div>
 

--- a/ui-src/src/containers/HoloFuelAppContainer.tsx
+++ b/ui-src/src/containers/HoloFuelAppContainer.tsx
@@ -112,7 +112,7 @@ const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
   //// PROPOSAL CASE :
       // payload === {to, amount, notes?, deadline?, request?}
       propose_payment : (payload) => {console.log("dispatching proposal"); dispatch(ProposalAsyncAction.create(payload))},
-      receive_payment : (payload) => {console.log("dispatching receive_payment"); dispatch(ReceivePaymentAsyncAction.create(payload))},
+      receive_payment : (payload) => {console.log("dispatching receive_payment" + JSON.stringify(payload)); dispatch(ReceivePaymentAsyncAction.create(payload))},
 
   // NB: API not yet available...
       // reject_payment : () => {console.log("dispatching reject_payment"); dispatch(RejectPaymentAsyncAction.create({}))}

--- a/ui-src/src/reducers/transactionReducer.ts
+++ b/ui-src/src/reducers/transactionReducer.ts
@@ -45,7 +45,8 @@ export const INITIAL_STATE: State = {
     balance: null,
     credit: null,
     payable: null,
-    receivable: null
+    receivable: null,
+    fees: null
   },
   list_of_pending  : {},
   list_of_transactions: {
@@ -53,7 +54,8 @@ export const INITIAL_STATE: State = {
       balance: null,
       credit: null,
       payable: null,
-      receivable: null
+      receivable: null,
+      fees: null
     },
     newer: {
       since: "",
@@ -78,6 +80,7 @@ export const INITIAL_STATE: State = {
           Request: {
             to: "",
             amount: "",
+	    fee: "",
             notes: "",
             deadline: "",
             request: ""
@@ -87,6 +90,7 @@ export const INITIAL_STATE: State = {
           balance: 0,
           payable: 0,
           receivable: 0,
+          fees: 0,
           credit: 0 // ** added **
         }
     }]
@@ -96,6 +100,7 @@ export const INITIAL_STATE: State = {
   view_specific_request:{
       to: "",
       amount: "",
+      fee: "",
       notes: "",
       deadline: ""
   },
@@ -105,6 +110,7 @@ export const INITIAL_STATE: State = {
       tx: {
         to: "",
         amount: "",
+	fee: "",
         notes: "",
         deadline: ""
       }

--- a/ui-src/src/utils/transaction-data-refactor.ts
+++ b/ui-src/src/utils/transaction-data-refactor.ts
@@ -12,6 +12,7 @@ const dataRefactor = (transaction_details: any) => {
         counterparty: transaction.counterparty,
         txAuthor: transaction.txAuthor || undefined,
         amount:  transaction.amount,
+        fee:  transaction.fee,
         event: transaction.event,
         status: transaction.status,
         transaction_timestamp: transaction.transactionTimestamp, //timestamp of the current Transaction
@@ -66,10 +67,11 @@ const refactorListOfPending = (list_of_pending:any) => {
   const  list_of_proposals =  list_of_pending.proposals.map((p:any) => {
     return {
       originTimeStamp: p.event[1],
-      amount:p.event[2].Proposal.tx.amount,
+      amount: p.event[2].Proposal.tx.amount,
+      fee: p.event[2].Proposal.tx.fee,
       originEvent:p.event[2].Proposal.request ? "Request" : "Proposal",
       event: "Proposal",
-      counterparty:p.event[2].Proposal.tx.from,
+      counterparty: p.event[2].Proposal.tx.from,
       txAuthor: p.event[2].Proposal.tx.to,
       status: "pending/recipient",
       dueDate: p.event[2].Proposal.tx.deadline,
@@ -86,7 +88,8 @@ const refactorListOfPending = (list_of_pending:any) => {
   const  list_of_requests =  list_of_pending.requests.map((r:any) => {
       return {
       originTimeStamp: r.event[1],
-      amount:r.event[2].Request.amount,
+      amount: r.event[2].Request.amount,
+      fee: r.event[2].Request.fee,
       originEvent:"Request",
       event: "Request",
       counterparty:r.event[2].Request.to,
@@ -116,6 +119,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
     let txEvent:string | undefined = undefined;
     let originEvent:string | undefined = undefined;
     let amount: number | null = null;
+    let fee: number | null = null;
     let counterparty: string | undefined = undefined;
     let dueDate: string | undefined = undefined;
     let notes: string | undefined = undefined;
@@ -126,6 +130,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
       txEvent = "Request";
       originEvent = "Request";
       amount =  event.Request.amount;
+      fee = event.Request.fee;
       counterparty = event.Request.from;
       dueDate = event.Request.deadline;
       notes = event.Request.notes;
@@ -136,6 +141,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
       txEvent="Proposal"
       originEvent = event.Proposal.request ? "Request" : "Proposal";
       amount =  event.Proposal.tx.amount;
+      fee = event.Proposal.tx.fee;
       counterparty = event.Proposal.tx.to;
       dueDate = event.Proposal.tx.deadline;
       notes = event.Proposal.tx.notes;
@@ -146,6 +152,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
       txEvent="Invoice"
       originEvent = event.Invoice.proposal.request ? "Request" : "Proposal";
       amount =  event.Invoice.proposal.tx.amount;
+      fee = event.Invoice.proposal.tx.fee;
       counterparty = event.Invoice.proposal.tx.from;
       dueDate = event.Invoice.proposal.tx.deadline;
       notes = event.Invoice.proposal.tx.notes;
@@ -156,6 +163,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
       txEvent="Receipt"
       originEvent = event.Receipt.cheque.invoice.proposal.request ? "Request" : "Proposal";
       amount =  event.Receipt.cheque.invoice.proposal.tx.amount;
+      fee = event.Receipt.cheque.invoice.proposal.tx.fee;
       counterparty = event.Receipt.cheque.invoice.proposal.tx.from;
       dueDate = event.Receipt.cheque.invoice.proposal.tx.deadline;
       notes = event.Receipt.cheque.invoice.proposal.tx.notes;
@@ -166,6 +174,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
       txEvent="Cheque"
       originEvent = event.Cheque.invoice.proposal ? "Request" : "Proposal";
       amount =  event.Cheque.invoice.proposal.tx.amount;
+      fee = event.Cheque.invoice.proposal.tx.fee;
       counterparty = event.Cheque.invoice.proposal.tx.to;
       dueDate = event.Cheque.invoice.proposal.tx.deadline;
       notes = event.Cheque.invoice.proposal.tx.notes;
@@ -187,6 +196,7 @@ export const refactorListOfTransactions = (list_of_transactions: any, list_of_pe
         originCommitHash, // tx origin commit hash
         eventCommitHash: tx.origin, // 'origin' commit hash for the currently displayed Transaction
         amount,
+	fee,
         originEvent,
         event: txEvent,
         counterparty,

--- a/ui-src/src/utils/types.ts
+++ b/ui-src/src/utils/types.ts
@@ -69,6 +69,7 @@ export type ProposalActionParam = {
 export type Transaction = {
     to: Address,
     amount: string,
+    fee: string,
     notes?: string,
     deadline?: DateTimeString | Moment | string | undefined,
     // transaction should not have request.. track what requires this and refactor/rework...
@@ -105,13 +106,15 @@ export type Ledger = {
   balance: number | null,
   credit: number | null,
   payable: number | null,
-  receivable: number | null
+  receivable: number | null,
+  fees: number | null
 }
 
 export type Adjustment = {
   balance: number,
   payable: number,
   receivable: number,
+  fees: number,
   credit?: number
 }
 


### PR DESCRIPTION
o Add `fees` to Adjustment and Ledger
o Add `fee` to Transaction
o Change summary page to show Credit, Balance, Payable and Fees

I've pushed the Fees handling code to holofuel `develop` already, but haven't pushed this to `develop` in this repo, yet.  I've tested it, and it seems to work.  

Of course, the Summary display is a little more cluttered, which we'll have to fix, but the account's "Available" balance is now the sum of Credit + Balance - Payable, so I wanted to show those components so the user could see and understand why their balance is lower than expected if they owe fees.

The Fees remain part of the account's `payable` value, until they are paid to the Holo Fee account (not yet implemented).  So, when you send funds, you lose access to the amount you owe in fees...